### PR TITLE
Optimized server.lua

### DIFF
--- a/patino_hospital/server/main.lua
+++ b/patino_hospital/server/main.lua
@@ -8,8 +8,8 @@ ESX.RegisterServerCallback('patino_hospital:canPay', function(source, cb, price)
     local xPlayer = ESX.GetPlayerFromId(source)
     local price = Config.ReviveInvoice
 
-    if xPlayer.getAccount('money').money >= price then
-        xPlayer.removeAccountMoney('money', price)
+    if xPlayer.getMoney() >= price then
+        xPlayer.removeMoney(price)
         cb(true)
     else
         cb(false)
@@ -17,20 +17,15 @@ ESX.RegisterServerCallback('patino_hospital:canPay', function(source, cb, price)
 end)
 
 ESX.RegisterServerCallback('patino_hospital:checkEMS', function(source, cb, emsRequired)
-    local xPlayer = ESX.GetPlayerFromId(source)
-    local xPlayers = ESX.GetPlayers()
-    local emsConnected = 0
-    local emsRequired = Config.EMSRequired
-    
-
     if Config.UsingESXLegacy then
         local xPlayers = ESX.GetExtendedPlayers('job', Config.EMSJobName)
-        for _, xPlayer in pairs(xPlayers) do
-            if xPlayer.job.name == Config.EMSJobName then
-                emsConnected = emsConnected + 1
-            end
+        if #xPlayers >= Config.EMSRequired then
+            cb(true)
+        else
+            cb(false)
         end
     else
+        local emsConnected = 0
         local xPlayers = ESX.GetPlayers()
         for i=1, #xPlayers, 1 do
             local xPlayer = ESX.GetPlayerFromId(xPlayers[i])
@@ -38,13 +33,11 @@ ESX.RegisterServerCallback('patino_hospital:checkEMS', function(source, cb, emsR
                 emsConnected = emsConnected + 1
             end
         end
-    end
-
-    if emsConnected >= emsRequired then
-        cb(true)
-    else
-        cb(false)
-    end
         
-
+        if emsConnected >= Config.EMSRequired then
+            cb(true)
+        else
+            cb(false)
+        end
+    end
 end)


### PR DESCRIPTION
- Replaced `xPlayer.getAccount('money').money` to `xPlayer.getMoney()`
- Replaced `xPlayer.removeAccountMoney('money', price)` to `xPlayer.removeMoney(price)`
- Use `#xPlayers` to count the number of EMS instead of looping trough it (ESX Legacy)
